### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here: [http://docs.rs/sofa](http://docs.rs/sofa)
 
 ```toml
 [dependencies]
-sofa = "0.5.1"
+sofa = "0.5"
 ```
 
 ## Description


### PR DESCRIPTION
With new update to 0.5.2, the readme still showed 0.5.1. Instead of changing it, it is better to stick to "0.5" (as "0.5" means "^0.5.0" it shouldn't be a problem). The only issue is you have breaking changes from 0.5.x to the 0.5.(x+1) then the users have to specify the entire version. 