### PR TITLE
clean all potentially panicking unwraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+- Added failure dependency
+- Added Client::make_db
+- Added docker-compose.yml
+- Changed SofaError to derive failure
+- Changed Client::check_status
+- Changed Client::create_path
+- Changed Client::db
+- Changed Client::delete
+- Changed Client::destroy_db
+- Changed Client::get
+- Changed Client::gzip
+- Changed Client::head
+- Changed Client::list_dbs
+- Changed Client::new
+- Changed Client::post
+- Changed Client::pub
+- Changed Client::req
+- Changed Client::timeout
+- Changed Database::create
+- Changed Database::ensure_index
+- Changed Database::find
+- Changed Database::get
+- Changed Database::insert_index
+- Changed Database::read_indexes
+- Changed Database::save

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 ]
 
 [dependencies]
+failure = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+
+  couchdb:
+    image: couchdb:2.2
+    restart: always
+    ports:
+      - '5984:5984'

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,35 +1,3 @@
-use std::{error, fmt};
-
-/// Custom error type
-#[derive(Debug)]
-pub struct SofaError {
-    err: String
-}
-
-impl error::Error for SofaError {
-    fn description(&self) -> &str {
-        &self.err
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
-}
-
-impl fmt::Display for SofaError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.err)
-    }
-}
-
-impl From<String> for SofaError {
-    fn from(s: String) -> SofaError {
-        SofaError { err: s }
-    }
-}
-
-impl From<&'static str> for SofaError {
-    fn from(s: &str) -> SofaError {
-        SofaError { err: s!(s) }
-    }
-}
+#[derive(Fail, Debug)]
+#[fail(display = "Custom error: {}", _0)]
+pub struct SofaError(pub String);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 //!
 //! [Yellow Innovation's website and works](http://yellowinnovation.fr/en/)
 
+#[macro_use]
+extern crate failure;
 extern crate reqwest;
 extern crate serde;
 #[macro_use]
@@ -135,21 +137,21 @@ mod sofa_tests {
 
         #[test]
         fn a_should_check_couchdbs_status() {
-            let client = Client::new("http://localhost:5984".into());
+            let client = Client::new("http://localhost:5984".into()).unwrap();
             let status = client.check_status();
-            assert!(status.is_some())
+            assert!(status.is_ok())
         }
 
         #[test]
         fn b_should_create_sofa_test_db() {
-            let client = Client::new("http://localhost:5984".into());
+            let client = Client::new("http://localhost:5984".into()).unwrap();
             let dbw = client.db("sofa_test");
             assert!(dbw.is_ok());
         }
 
         #[test]
         fn c_should_create_a_document() {
-            let client = Client::new("http://localhost:5984".into());
+            let client = Client::new("http://localhost:5984".into()).unwrap();
             let dbw = client.db("sofa_test");
             assert!(dbw.is_ok());
             let db = dbw.unwrap();
@@ -166,8 +168,8 @@ mod sofa_tests {
 
         #[test]
         fn d_should_destroy_the_db() {
-            let client = Client::new("http://localhost:5984".into());
-            assert!(client.destroy_db("sofa_test"));
+            let client = Client::new("http://localhost:5984".into()).unwrap();
+            assert!(client.destroy_db("sofa_test").unwrap());
         }
     }
 
@@ -175,7 +177,7 @@ mod sofa_tests {
         use *;
 
         fn setup() -> (Client, Database, Document) {
-            let client = Client::new("http://localhost:5984".into());
+            let client = Client::new("http://localhost:5984".into()).unwrap();
             let dbw = client.db("sofa_test");
             assert!(dbw.is_ok());
             let db = dbw.unwrap();
@@ -193,7 +195,7 @@ mod sofa_tests {
         }
 
         fn teardown(client: Client) {
-            assert!(client.destroy_db("sofa_test"))
+            assert!(client.destroy_db("sofa_test").unwrap())
         }
 
         #[test]
@@ -248,7 +250,7 @@ mod sofa_tests {
         fn e_should_list_indexes_in_db() {
             let (client, db, _) = setup_create_indexes();
 
-            let index_list = db.read_indexes();
+            let index_list = db.read_indexes().unwrap();
             assert!(index_list.indexes.len() > 1);
             let ref findex = index_list.indexes[1];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,20 +139,22 @@ mod sofa_tests {
         fn a_should_check_couchdbs_status() {
             let client = Client::new("http://localhost:5984".into()).unwrap();
             let status = client.check_status();
-            assert!(status.is_ok())
+            assert!(status.is_ok());
         }
 
         #[test]
         fn b_should_create_sofa_test_db() {
             let client = Client::new("http://localhost:5984".into()).unwrap();
-            let dbw = client.db("sofa_test");
+            let dbw = client.db("b_should_create_sofa_test_db");
             assert!(dbw.is_ok());
+
+            let _ = client.destroy_db("b_should_create_sofa_test_db");
         }
 
         #[test]
         fn c_should_create_a_document() {
             let client = Client::new("http://localhost:5984".into()).unwrap();
-            let dbw = client.db("sofa_test");
+            let dbw = client.db("c_should_create_a_document");
             assert!(dbw.is_ok());
             let db = dbw.unwrap();
 
@@ -163,22 +165,26 @@ mod sofa_tests {
             assert!(ndoc_result.is_ok());
 
             let mut doc = ndoc_result.unwrap();
-            assert_eq!(doc["thing"], json!(true))
+            assert_eq!(doc["thing"], json!(true));
+
+            let _ = client.destroy_db("c_should_create_a_document");
         }
 
         #[test]
         fn d_should_destroy_the_db() {
             let client = Client::new("http://localhost:5984".into()).unwrap();
-            assert!(client.destroy_db("sofa_test").unwrap());
+            let _ = client.db("d_should_destroy_the_db");
+
+            assert!(client.destroy_db("d_should_destroy_the_db").unwrap());
         }
     }
 
     mod b_db {
         use *;
 
-        fn setup() -> (Client, Database, Document) {
+        fn setup(dbname: &'static str) -> (Client, Database, Document) {
             let client = Client::new("http://localhost:5984".into()).unwrap();
-            let dbw = client.db("sofa_test");
+            let dbw = client.db(dbname);
             assert!(dbw.is_ok());
             let db = dbw.unwrap();
 
@@ -194,13 +200,13 @@ mod sofa_tests {
             (client, db, doc)
         }
 
-        fn teardown(client: Client) {
-            assert!(client.destroy_db("sofa_test").unwrap())
+        fn teardown(client: Client, dbname: &'static str) {
+            assert!(client.destroy_db(dbname).unwrap())
         }
 
         #[test]
         fn a_should_update_a_document() {
-            let (client, db, mut doc) = setup();
+            let (client, db, mut doc) = setup("a_should_update_a_document");
 
             doc["thing"] = json!(false);
 
@@ -209,26 +215,26 @@ mod sofa_tests {
             let new_doc = save_result.unwrap();
             assert_eq!(new_doc["thing"], json!(false));
 
-            teardown(client);
+            teardown(client, "a_should_update_a_document");
         }
 
         #[test]
         fn b_should_remove_a_document() {
-            let (client, db, doc) = setup();
+            let (client, db, doc) = setup("b_should_remove_a_document");
             assert!(db.remove(doc));
 
-            teardown(client);
+            teardown(client, "b_should_remove_a_document");
         }
 
         #[test]
         fn c_should_get_a_single_document() {
-            let (client, _, _) = setup();
+            let (client, _, _) = setup("c_should_get_a_single_document");
             assert!(true);
-            teardown(client);
+            teardown(client, "c_should_get_a_single_document");
         }
 
-        fn setup_create_indexes() -> (Client, Database, Document) {
-            let (client, db, doc) = setup();
+        fn setup_create_indexes(dbname: &'static str) -> (Client, Database, Document) {
+            let (client, db, doc) = setup(dbname);
 
             let spec = types::IndexFields::new(vec![types::SortSpec::Simple(s!("thing"))]);
 
@@ -241,38 +247,38 @@ mod sofa_tests {
 
         #[test]
         fn d_should_create_index_in_db() {
-            let (client, db, _) = setup_create_indexes();
+            let (client, db, _) = setup_create_indexes("d_should_create_index_in_db");
             assert!(true);
-            teardown(client);
+            teardown(client, "d_should_create_index_in_db");
         }
 
         #[test]
         fn e_should_list_indexes_in_db() {
-            let (client, db, _) = setup_create_indexes();
+            let (client, db, _) = setup_create_indexes("e_should_list_indexes_in_db");
 
             let index_list = db.read_indexes().unwrap();
             assert!(index_list.indexes.len() > 1);
             let ref findex = index_list.indexes[1];
 
             assert_eq!(findex.name.as_str(), "thing-index");
-            teardown(client);
+            teardown(client, "e_should_list_indexes_in_db");
         }
 
         #[test]
         fn f_should_ensure_index_in_db() {
-            let (client, db, _) = setup();
+            let (client, db, _) = setup("f_should_ensure_index_in_db");
 
             let spec = types::IndexFields::new(vec![types::SortSpec::Simple(s!("thing"))]);
 
             let res = db.ensure_index("thing-index".into(), spec);
             assert!(res.is_ok());
 
-            teardown(client);
+            teardown(client, "f_should_ensure_index_in_db");
         }
 
         #[test]
         fn f_should_find_documents_in_db() {
-            let (client, db, doc) = setup_create_indexes();
+            let (client, db, doc) = setup_create_indexes("f_should_find_documents_in_db");
 
             let documents_res = db.find(json!({
                 "selector": {
@@ -288,7 +294,7 @@ mod sofa_tests {
             let documents = documents_res.unwrap();
             assert_eq!(documents.rows.len(), 1);
 
-            teardown(client);
+            teardown(client, "f_should_find_documents_in_db");
         }
     }
 }

--- a/src/types/system.rs
+++ b/src/types/system.rs
@@ -2,14 +2,15 @@
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
 pub struct CouchVendor {
     pub name: String,
-    pub version: String
+    pub version: Option<String>
 }
 
 /// Couch status abstraction
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
 pub struct CouchStatus {
     pub couchdb: String,
-    pub uuid: String,
+    pub git_sha: Option<String>,
+    pub uuid: Option<String>,
     pub version: String,
     pub vendor: CouchVendor
 }


### PR DESCRIPTION
Here's my attempt at this for #3 !

The crux is leveraging the [failure](https://crates.io/crates/failure) crate.

I was not able to eliminate unwrap in the following:
- DocumentCollection::index
- DocumentCollection::index_mut
- Model::from_document
- Model::to_document
- All instances of unwrap in tests remain

Additionally, I was not able to figure out how to run all the tests as they seemed to be interfering with each other. So, each test uses it's own database.

Feedback and modifications welcome! 😀