### PR TITLE
Generic arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sofa - CouchDB for Rust
 
-[![Crates.io](https://img.shields.io/crates/v/sofa.svg)](https://crates.io/crates/sofa)
+[![Crates.io](https://img.shields.io/crates/v/sofa.svg)](https://crates.io/crates/sofa)[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FYellowInnovation%2Fsofa.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FYellowInnovation%2Fsofa?ref=badge_shield)
+
 [![docs.rs](https://docs.rs/sofa/badge.svg)](https://docs.rs/sofa)
 
 ![sofa-logo](https://raw.githubusercontent.com/YellowInnovation/sofa/master/docs/logo-sofa.png "Logo Sofa")
@@ -53,6 +54,9 @@ Licensed under either of these:
    [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or
    [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT))
+
+
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FYellowInnovation%2Fsofa.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FYellowInnovation%2Fsofa?ref=badge_large)
 
 ## Yellow Innovation
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -68,8 +68,8 @@ impl Document {
 
     /// Recursively populates field (must be an array of IDs from another
     /// database) with provided database documents
-    pub fn populate(&mut self, field: &String, db: Database) -> &Self {
-        let ref val = self[field].clone();
+    pub fn populate<S: AsRef<str>>(&mut self, field: S, db: Database) -> &Self {
+        let ref val = self[field.as_ref()].clone();
         if *val == Value::Null {
             return self;
         }
@@ -84,7 +84,7 @@ impl Document {
 
         match data {
             Ok(data) => {
-                self[field] = data.into_iter()
+                self[field.as_ref()] = data.into_iter()
                     .filter_map(|d: Value| {
                         let did = match d["_id"].as_str() {
                             Some(did) => did,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,14 +156,14 @@ mod sofa_tests {
 
         #[test]
         fn a_should_check_couchdbs_status() {
-            let client = Client::new("http://localhost:5984".into()).unwrap();
+            let client = Client::new("http://localhost:5984").unwrap();
             let status = client.check_status();
             assert!(status.is_ok());
         }
 
         #[test]
         fn b_should_create_sofa_test_db() {
-            let client = Client::new("http://localhost:5984".into()).unwrap();
+            let client = Client::new("http://localhost:5984").unwrap();
             let dbw = client.db("b_should_create_sofa_test_db");
             assert!(dbw.is_ok());
 
@@ -172,7 +172,7 @@ mod sofa_tests {
 
         #[test]
         fn c_should_create_a_document() {
-            let client = Client::new("http://localhost:5984".into()).unwrap();
+            let client = Client::new("http://localhost:5984").unwrap();
             let dbw = client.db("c_should_create_a_document");
             assert!(dbw.is_ok());
             let db = dbw.unwrap();
@@ -191,7 +191,7 @@ mod sofa_tests {
 
         #[test]
         fn d_should_destroy_the_db() {
-            let client = Client::new("http://localhost:5984".into()).unwrap();
+            let client = Client::new("http://localhost:5984").unwrap();
             let _ = client.db("d_should_destroy_the_db");
 
             assert!(client.destroy_db("d_should_destroy_the_db").unwrap());
@@ -202,7 +202,7 @@ mod sofa_tests {
         use *;
 
         fn setup(dbname: &'static str) -> (Client, Database, Document) {
-            let client = Client::new("http://localhost:5984".into()).unwrap();
+            let client = Client::new("http://localhost:5984").unwrap();
             let dbw = client.db(dbname);
             assert!(dbw.is_ok());
             let db = dbw.unwrap();
@@ -257,7 +257,7 @@ mod sofa_tests {
 
             let spec = types::IndexFields::new(vec![types::SortSpec::Simple(s!("thing"))]);
 
-            let res = db.insert_index("thing-index".into(), spec);
+            let res = db.insert_index("thing-index", spec);
 
             assert!(res.is_ok());
 
@@ -289,7 +289,7 @@ mod sofa_tests {
 
             let spec = types::IndexFields::new(vec![types::SortSpec::Simple(s!("thing"))]);
 
-            let res = db.ensure_index("thing-index".into(), spec);
+            let res = db.ensure_index("thing-index", spec);
             assert!(res.is_ok());
 
             teardown(client, "f_should_ensure_index_in_db");


### PR DESCRIPTION
fixes #7 
I've made most of the functions generic over the input they actually need, rather than concrete types. I think there's still some work to be done to improve the api.

this is a minor breaking change as seen below-

## before
```
fn example(s: String) {
   let x: String = s;
}

fn main() {
   let my_str : &'static str = "example string";

  // this won't compile after the change as type ascriptions would be required to determine how to apply 'into()'
   example(my_str.into())
}
```
## after
```
fn example<S: Into<String>>(s: S) {
   let x: String = s.into();
}

fn main() {
   let my_str : &'static str = "example string";

  // consumer of library can now use any type which can be converted into a concrete string to call the function
   example(my_str)
}
```
